### PR TITLE
Display the counter on the Home page and implement the add sanctioned entity functionality

### DIFF
--- a/ClientApp/.gitignore
+++ b/ClientApp/.gitignore
@@ -34,6 +34,7 @@ npm-debug.log
 yarn-error.log
 testem.log
 /typings
+.angular/cache
 
 # System Files
 .DS_Store

--- a/ClientApp/src/app/app.module.ts
+++ b/ClientApp/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { RouterModule } from '@angular/router';
 
@@ -10,6 +10,7 @@ import { HomeComponent } from './components/home/home.component';
 import { CounterComponent } from './components/counter/counter.component';
 import { SanctionedEntitiesComponent } from './components/sanctioned-entities/sanctioned-entities.component';
 import { JumbotronCounterComponent } from './components/jumbotron-counter/jumbotron-counter.component';
+import { SanctionedEntityAddComponent } from './components/sanctioned-entity-add/sanctioned-entity-add.component';
 
 
 @NgModule({
@@ -19,16 +20,20 @@ import { JumbotronCounterComponent } from './components/jumbotron-counter/jumbot
     HomeComponent,
     CounterComponent,
     SanctionedEntitiesComponent,
+    SanctionedEntityAddComponent,
     JumbotronCounterComponent
   ],
   imports: [
     BrowserModule.withServerTransition({ appId: 'ng-cli-universal' }),
     HttpClientModule,
     FormsModule,
+    ReactiveFormsModule,
     RouterModule.forRoot([
       { path: '', component: HomeComponent, pathMatch: 'full' },
       { path: 'counter', component: CounterComponent },
       { path: 'sanctioned-entities', component: SanctionedEntitiesComponent },
+      { path: 'sanctioned-entities/add', component: SanctionedEntityAddComponent  },
+      { path: '**', redirectTo: '' }  // Wildcard route for a 404 page can be added here
     ])
   ],
   providers: [],

--- a/ClientApp/src/app/components/counter/counter.component.html
+++ b/ClientApp/src/app/components/counter/counter.component.html
@@ -2,6 +2,6 @@
 
 <p>This is a simple example of an Angular component.</p>
 
-<p aria-live="polite">Current count: <strong>{{ currentCount }}</strong></p>
+<p aria-live="polite">Current count: <strong>{{ currentCount$ | async }}</strong></p>
 
 <button class="btn btn-primary" (click)="incrementCounter()">Increment</button>

--- a/ClientApp/src/app/components/counter/counter.component.ts
+++ b/ClientApp/src/app/components/counter/counter.component.ts
@@ -1,13 +1,17 @@
 import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
+import { CounterService } from 'src/app/services/counter.service';
 
 @Component({
   selector: 'app-counter-component',
   templateUrl: './counter.component.html'
 })
 export class CounterComponent {
-  public currentCount = 0;
+  public currentCount$: Observable<number> = this.counterService.getCounter();
 
-  public incrementCounter() {
-    this.currentCount++;
+  constructor(private readonly counterService: CounterService) {}
+
+  public incrementCounter(): void {
+    this.counterService.increment();
   }
 }

--- a/ClientApp/src/app/components/jumbotron-counter/jumbotron-counter.component.html
+++ b/ClientApp/src/app/components/jumbotron-counter/jumbotron-counter.component.html
@@ -1,4 +1,4 @@
-<div class="jumbotron text-center">
+<div class="jumbotron text-center" aria-live="polite">
     <p>Current count:</p>
-    <p><strong>Please include the counter here</strong></p>
+    <p><strong>{{ currentCount$ | async }}</strong></p>
 </div>

--- a/ClientApp/src/app/components/jumbotron-counter/jumbotron-counter.component.ts
+++ b/ClientApp/src/app/components/jumbotron-counter/jumbotron-counter.component.ts
@@ -1,8 +1,13 @@
 import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
+import { CounterService } from 'src/app/services/counter.service';
 
 @Component({
   selector: 'app-jumbotron-counter',
   templateUrl: './jumbotron-counter.component.html'
 })
 export class JumbotronCounterComponent {
+  public currentCount$: Observable<number> = this.counterService.getCounter();
+
+  constructor(private readonly counterService: CounterService) {}
 }

--- a/ClientApp/src/app/components/sanctioned-entities/sanctioned-entities.component.html
+++ b/ClientApp/src/app/components/sanctioned-entities/sanctioned-entities.component.html
@@ -1,21 +1,35 @@
 <h1 id="tableLabel">Sanctioned Entities</h1>
 
-<p *ngIf="!entities"><em>Loading...</em></p>
+<div class="d-flex justify-content-end mb-3">
+  <a routerLink="/sanctioned-entities/add" class="btn btn-success">
+    + Add Entity
+  </a>
+</div>
 
-<table class='table table-striped' aria-labelledby="tableLabel" *ngIf="entities">
+<ng-container *ngIf="entities$ | async as entities; else loading">
+  <table
+    class="table table-striped"
+    aria-labelledby="tableLabel"
+    *ngIf="entities$ | async as entities"
+  >
     <thead>
-    <tr>
+      <tr>
         <th>Name</th>
         <th>Domicile</th>
         <th>Status</th>
-    </tr>
+      </tr>
     </thead>
     <tbody>
-    <tr *ngFor="let entity of entities">
+      <tr *ngFor="let entity of entities">
         <td>{{ entity.name }}</td>
         <td>{{ entity.domicile }}</td>
         <td *ngIf="entity.accepted" class="text-success">Accepted</td>
         <td *ngIf="!entity.accepted" class="text-danger">Rejected</td>
-    </tr>
+      </tr>
     </tbody>
-</table>
+  </table>
+</ng-container>
+
+<ng-template #loading>
+  <p><em>Loading...</em></p>
+</ng-template>

--- a/ClientApp/src/app/components/sanctioned-entities/sanctioned-entities.component.ts
+++ b/ClientApp/src/app/components/sanctioned-entities/sanctioned-entities.component.ts
@@ -1,17 +1,15 @@
 import { Component } from '@angular/core';
 import { SanctionedEntity } from '../../models/sanctioned-entity';
 import { SanctionedEntitiesService } from '../../services/sanctioned-entities.service';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-sanctioned-entities',
-  templateUrl: './sanctioned-entities.component.html'
+  templateUrl: './sanctioned-entities.component.html',
 })
 export class SanctionedEntitiesComponent {
-  public entities: SanctionedEntity[] = [];
+  public entities$: Observable<SanctionedEntity[]> =
+    this.entitiesService.getSanctionedEntities();
 
-  constructor(private entitiesService: SanctionedEntitiesService) {
-    entitiesService.getSanctionedEntities().subscribe(entities => {
-      this.entities = entities;
-    });
-  }
+  constructor(private entitiesService: SanctionedEntitiesService) {}
 }

--- a/ClientApp/src/app/components/sanctioned-entity-add/sanctioned-entity-add.component.html
+++ b/ClientApp/src/app/components/sanctioned-entity-add/sanctioned-entity-add.component.html
@@ -1,0 +1,90 @@
+<form class="mb-4" [formGroup]="entityForm" (ngSubmit)="addEntity()">
+  <div class="mb-3">
+    <label class="form-label" for="name"> Name </label>
+    <input
+      class="form-control"
+      formControlName="name"
+      id="name"
+      type="text"
+      [class.is-invalid]="
+        (entityForm.controls.name.touched || formSubmitted) &&
+        entityForm.controls.name.invalid
+      "
+    />
+    <div
+      class="invalid-feedback"
+      *ngIf="
+        (entityForm.controls.name.touched || formSubmitted) &&
+        entityForm.controls.name.hasError('required')
+      "
+    >
+      Name is required.
+    </div>
+  </div>
+
+  <div class="mb-3">
+    <label class="form-label" for="domicile">Domicile</label>
+    <input
+      class="form-control"
+      id="domicile"
+      formControlName="domicile"
+      type="text"
+      [class.is-invalid]="
+        (entityForm.controls.domicile.touched || formSubmitted) &&
+        entityForm.controls.domicile.invalid
+      "
+    />
+    <div
+      class="invalid-feedback"
+      *ngIf="
+        (entityForm.controls.domicile.touched || formSubmitted) &&
+        entityForm.controls.domicile.hasError('required')
+      "
+    >
+      Domicile is required.
+    </div>
+  </div>
+
+  <div
+    class="text-danger mb-2"
+    *ngIf="
+      (entityForm.errors?.['duplicateEntity'] &&
+        (formSubmitted || entityForm.touched))
+    "
+  >
+    An entity with the same name and domicile already exists.
+  </div>
+
+  <div class="form-check form-switch mb-3">
+    <input
+      class="form-check-input"
+      formControlName="accepted"
+      id="accepted"
+      type="checkbox"
+    />
+    <label class="form-check-label" for="accepted">Accepted</label>
+  </div>
+
+  <div *ngIf="formError" class="text-danger mb-2">{{ formError }}</div>
+
+  <div class="mt-3">
+    <button
+      class="btn btn-primary"
+      type="submit"
+      [disabled]="entityForm.invalid || isSaving"
+    >
+      <span
+        *ngIf="isSaving"
+        class="spinner-border spinner-border-sm me-2"
+      ></span>
+      Save
+    </button>
+    <button
+      class="btn btn-secondary ms-2"
+      type="button"
+      routerLink="/sanctioned-entities"
+    >
+      Cancel
+    </button>
+  </div>
+</form>

--- a/ClientApp/src/app/components/sanctioned-entity-add/sanctioned-entity-add.component.spec.ts
+++ b/ClientApp/src/app/components/sanctioned-entity-add/sanctioned-entity-add.component.spec.ts
@@ -1,0 +1,82 @@
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { of, throwError } from 'rxjs';
+
+import { SanctionedEntityAddComponent } from './sanctioned-entity-add.component';
+import { SanctionedEntitiesService } from '../../services/sanctioned-entities.service';
+
+describe('SanctionedEntityAddComponent', () => {
+  let component: SanctionedEntityAddComponent;
+  let fixture: ComponentFixture<SanctionedEntityAddComponent>;
+  let mockService: any;
+  let mockRouter: any;
+
+  beforeEach(() => {
+    mockService = {
+      addSanctionedEntity: jasmine.createSpy('addSanctionedEntity'),
+      getSanctionedEntities: jasmine
+        .createSpy('getSanctionedEntities')
+        .and.returnValue(of([])),
+    };
+
+    mockRouter = {
+      navigate: jasmine.createSpy('navigate'),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [ReactiveFormsModule],
+      declarations: [SanctionedEntityAddComponent],
+      providers: [
+        { provide: SanctionedEntitiesService, useValue: mockService },
+        { provide: Router, useValue: mockRouter },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SanctionedEntityAddComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should mark form as submitted and not call service if invalid', () => {
+    component.addEntity();
+    expect(component.formSubmitted).toBeTrue();
+    expect(mockService.addSanctionedEntity).not.toHaveBeenCalled();
+  });
+
+  it('should call service and navigate on successful add', fakeAsync(() => {
+    const entity = { name: 'Test', domicile: 'Earth', accepted: true };
+    component.entityForm.setValue(entity);
+    mockService.addSanctionedEntity.and.returnValue(of({}));
+
+    component.addEntity();
+    tick(); // simulate async
+
+    expect(component.isSaving).toBeFalse();
+    expect(mockService.addSanctionedEntity).toHaveBeenCalledWith(entity);
+    expect(mockRouter.navigate).toHaveBeenCalledWith(['/sanctioned-entities']);
+  }));
+
+  it('should handle error if service fails', fakeAsync(() => {
+    const entity = { name: 'Test', domicile: 'Earth', accepted: true };
+    component.entityForm.setValue(entity);
+    const error = { message: 'Duplicate entity' };
+    mockService.addSanctionedEntity.and.returnValue(throwError(() => error));
+
+    component.addEntity();
+    tick(); // simulate async
+
+    expect(component.isSaving).toBeFalse();
+    expect(component.formError).toBe('Duplicate entity');
+    expect(mockRouter.navigate).not.toHaveBeenCalled();
+  }));
+});

--- a/ClientApp/src/app/components/sanctioned-entity-add/sanctioned-entity-add.component.ts
+++ b/ClientApp/src/app/components/sanctioned-entity-add/sanctioned-entity-add.component.ts
@@ -1,0 +1,61 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { SanctionedEntity } from '../../models/sanctioned-entity';
+import { SanctionedEntitiesService } from '../../services/sanctioned-entities.service';
+import { sanctionedEntityValidator } from 'src/app/validators/sanctioned-entity.validator';
+import { take } from 'rxjs';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-sanctioned-entity-add',
+  templateUrl: './sanctioned-entity-add.component.html',
+})
+export class SanctionedEntityAddComponent {
+  public entityForm: FormGroup;
+  public formSubmitted = false;
+  public formError = '';
+  public isSaving = false;
+
+  constructor(
+    private fb: FormBuilder,
+    private router: Router,
+    private readonly entitiesService: SanctionedEntitiesService
+  ) {
+    this.entityForm = this.fb.group(
+      {
+        name: ['', Validators.required],
+        domicile: ['', Validators.required],
+        accepted: [false],
+      },
+      {
+        asyncValidators: [sanctionedEntityValidator(this.entitiesService)],
+        updateOn: 'blur',
+      }
+    );
+  }
+
+  public addEntity(): void {
+    this.formSubmitted = true;
+    this.formError = '';
+
+    if (this.entityForm.invalid) return;
+
+    this.isSaving = true;
+
+    const newEntity: SanctionedEntity = this.entityForm.value;
+
+    this.entitiesService
+      .addSanctionedEntity(newEntity)
+      .pipe(take(1))
+      .subscribe({
+        next: () => {
+          this.isSaving = false;
+          this.router.navigate(['/sanctioned-entities']);
+        },
+        error: (err) => {
+          this.isSaving = false;
+          this.formError = err.message || 'Failed to add entity';
+        },
+      });
+  }
+}

--- a/ClientApp/src/app/services/counter.service.ts
+++ b/ClientApp/src/app/services/counter.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from "@angular/core";
+import { BehaviorSubject, Observable } from "rxjs";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CounterService {
+  private counter: BehaviorSubject<number> = new BehaviorSubject<number>(0);
+
+  public getCounter(): Observable<number> {
+    return this.counter.asObservable();
+  }
+
+  public increment(): void {
+    this.counter.next(this.counter.value + 1);
+  }
+}

--- a/ClientApp/src/app/services/sanctioned-entities.service.ts
+++ b/ClientApp/src/app/services/sanctioned-entities.service.ts
@@ -4,10 +4,9 @@ import { SanctionedEntity } from '../models/sanctioned-entity';
 import { Observable } from 'rxjs';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class SanctionedEntitiesService {
-
   private readonly apiUrl: string;
   private readonly path = 'sanctioned-entities';
 
@@ -18,5 +17,10 @@ export class SanctionedEntitiesService {
   public getSanctionedEntities(): Observable<SanctionedEntity[]> {
     const url = this.apiUrl + this.path;
     return this.http.get<SanctionedEntity[]>(url);
+  }
+
+  public addSanctionedEntity(entity: SanctionedEntity): Observable<void> {
+    const url = this.apiUrl + this.path;
+    return this.http.post<void>(url, entity);
   }
 }

--- a/ClientApp/src/app/validators/sanctioned-entity.validator.ts
+++ b/ClientApp/src/app/validators/sanctioned-entity.validator.ts
@@ -1,0 +1,33 @@
+import {
+  AbstractControl,
+  AsyncValidatorFn,
+  ValidationErrors,
+} from '@angular/forms';
+import { Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { SanctionedEntitiesService } from '../services/sanctioned-entities.service';
+
+export function sanctionedEntityValidator(
+  service: SanctionedEntitiesService
+): AsyncValidatorFn {
+  return (control: AbstractControl): Observable<ValidationErrors | null> => {
+    const name = control.get('name')?.value;
+    const domicile = control.get('domicile')?.value;
+
+    // Skip validation if name or domicile is missing
+    if (!name || !domicile) {
+      return of(null);
+    }
+
+    return service.getSanctionedEntities().pipe(
+      map((entities) => {
+        const exists = entities.some(
+          (e) =>
+            e.name.toLowerCase() === name.toLowerCase() &&
+            e.domicile.toLowerCase() === domicile.toLowerCase()
+        );
+        return exists ? { duplicateEntity: true } : null;
+      })
+    );
+  };
+}

--- a/Controllers/SanctionedEntitiesController.cs
+++ b/Controllers/SanctionedEntitiesController.cs
@@ -1,4 +1,5 @@
-﻿using ajgre_technical_interview.Services;
+﻿using ajgre_technical_interview.Models;
+using ajgre_technical_interview.Services;
 using Microsoft.AspNetCore.Mvc;
 
 namespace ajgre_technical_interview.Controllers
@@ -28,6 +29,20 @@ namespace ajgre_technical_interview.Controllers
                 return Problem(ex.Message);
             }
 
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> CreateSanctionedEntity([FromBody] SanctionedEntity entity)
+        {
+            try
+            {
+                var created = await _databaseService.CreateSanctionedEntityAsync(entity);
+                return CreatedAtAction(nameof(GetSanctionedEntities), new { id = created.Id }, created);
+            }
+            catch (Exception ex)
+            {
+                return Problem(ex.Message);
+            }
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
 using ajgre_technical_interview.Services;
+using ajgre_technical_interview.Validators;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -6,6 +7,23 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllersWithViews();
 
 builder.Services.AddSingleton<IDatabaseService, DatabaseService>();
+builder.Services.AddSingleton<ISanctionedEntityValidator, SanctionedEntityValidator>();
+
+// Configure CORS
+builder.Services.AddCors(options =>
+{
+    if (builder.Environment.IsDevelopment())
+    {
+        // Dev: allow localhost
+        options.AddPolicy("CorsPolicy", policy =>
+        {
+            policy
+                .SetIsOriginAllowed(origin => new Uri(origin).Host == "localhost")
+                .AllowAnyMethod()
+                .AllowAnyHeader();
+        });
+    }
+});
 
 var app = builder.Build();
 
@@ -20,6 +38,8 @@ app.UseHttpsRedirection();
 app.UseStaticFiles();
 app.UseRouting();
 
+// Use the CORS policy
+app.UseCors("CorsPolicy");
 
 app.MapControllerRoute(
     name: "default",

--- a/README.md
+++ b/README.md
@@ -3,20 +3,24 @@
 The project is an ASP.NET Core application with Angular to test basic technical skills of the candidates for Software Engineering positions.
 
 ## Structure
+
 Application uses .NET Core 6
 ClientApp uses Angular 14
 
 The project does not use any database. Sample _database_ items are stored in `SanctionedEntities` list in `DatabaseService`. For the purpose of this exercise this is sufficient, we do not expect candidates to embed ORM or CRUD functionality. However if candidates wish to mock a DAL that is acceptable - but the focus of the time spent here should be on C# and Angular development.
 
 ## Requirements
+
 - Node.js version 16 or later
 - ASP.NET Core 6
 - Visual Studio/VS Code IDE
 
 ## Getting started
+
 Open the solution in Visual Studio and run IIS Express. This will automatically install the required packages and will open the app in the browser. The Home page will provide you with the details about the content of the application and the tasks you are asked to tackle.
 
 ## Scope of exercise
+
 As an insurance organisation, we are prevented from doing business with certain organisations that are subject to sanctions by Government. These sanctioned entities are different across the globe and it is vital we keep track of which organisations are sanctioned in which countries.
 
 This is a simple ASP.Net Core application with Angular, its goal is to keep a track of the number of organisations subject to sanctions in various countries and display these to the user. It includes following tabs:
@@ -27,13 +31,29 @@ This is a simple ASP.Net Core application with Angular, its goal is to keep a tr
 Please tackle the following problems - use whatever approaches you'd normally use in your day to day work:
 
 1. Display the counter on the home page
-* Number on the Counter page should always match the one on the Home page
-* The count should persist when switching between the tabs
+
+- Number on the Counter page should always match the one on the Home page
+- The count should persist when switching between the tabs
+
 2. Add a capability to add a sanctioned entity
-* Add a form to provide details of a new sanctioned entity
-* The status should use a Bootstrap switch
-* No property of the sanctioned entity can be empty
-* The code needs to ensure that there cannot be more than one entity with the same name and domicile
+
+- Add a form to provide details of a new sanctioned entity
+- The status should use a Bootstrap switch
+- No property of the sanctioned entity can be empty
+- The code needs to ensure that there cannot be more than one entity with the same name and domicile
 
 ## Submitting your work
+
 Please create a pull request for the code you have developed and submit no later than 2 hours before your scheduled interview time. If you have any issues submitting your PR, please contact your recruitment partner.
+
+## Next Steps / Improvements
+
+- Increase test coverage for frontend components and backend services/controllers.
+- Implement internationalization (i18n): remove hard-coded strings in frontend and backend.
+- Improve error handling: show user-friendly messages.
+- Create a feature module for sanctioned entities and lazy-load it to improve performance.
+- Add structured logging in the backend for requests, errors, and key events.
+- Apply Smart / Dumb component pattern to sanctioned entity components (like Home and Counter).
+- Add edit Sanctioned Entity functionality with validation and UI updates.
+- Upgrade Angular to the latest version
+- Consider standalone components in a future Angular upgrade (Angular 14 does not fully support them).

--- a/Services/DatabaseService.cs
+++ b/Services/DatabaseService.cs
@@ -1,9 +1,12 @@
 ﻿using ajgre_technical_interview.Models;
+using ajgre_technical_interview.Validators;
 
 namespace ajgre_technical_interview.Services
 {
     public class DatabaseService : IDatabaseService
     {
+        private readonly ISanctionedEntityValidator _validator;
+
         private static readonly IList<SanctionedEntity> SanctionedEntities = new List<SanctionedEntity>
         {
             new SanctionedEntity { Name = "Forbidden Company", Domicile = "Mars", Accepted = false },
@@ -11,6 +14,11 @@ namespace ajgre_technical_interview.Services
             new SanctionedEntity { Name = "Good Ltd", Domicile = "Saturn", Accepted = true },
             new SanctionedEntity { Name = "Evil Plc", Domicile = "Venus", Accepted = false }
         };
+
+        public DatabaseService(ISanctionedEntityValidator validator)
+        {
+            _validator = validator;
+        }
 
         public async Task<IList<SanctionedEntity>> GetSanctionedEntitiesAsync()
         {
@@ -29,6 +37,7 @@ namespace ajgre_technical_interview.Services
 
         public async Task<SanctionedEntity> CreateSanctionedEntityAsync(SanctionedEntity sanctionedEntity)
         {
+            await _validator.ValidateAsync(sanctionedEntity, SanctionedEntities);
             SanctionedEntities.Add(sanctionedEntity);
             return await Task.FromResult(sanctionedEntity);
         }

--- a/Validators/ISanctionedEntityValidator.cs
+++ b/Validators/ISanctionedEntityValidator.cs
@@ -1,0 +1,9 @@
+﻿using ajgre_technical_interview.Models;
+
+namespace ajgre_technical_interview.Validators
+{
+    public interface ISanctionedEntityValidator
+    {
+        Task ValidateAsync(SanctionedEntity entity, IEnumerable<SanctionedEntity> existingEntities);
+    }
+}

--- a/Validators/SanctionedEntityValidator .cs
+++ b/Validators/SanctionedEntityValidator .cs
@@ -1,0 +1,28 @@
+﻿using ajgre_technical_interview.Models;
+
+namespace ajgre_technical_interview.Validators
+{
+    public class SanctionedEntityValidator : ISanctionedEntityValidator
+    {
+        public Task ValidateAsync(SanctionedEntity entity, IEnumerable<SanctionedEntity> existingEntities)
+        {
+            if (entity == null)
+                throw new ArgumentNullException(nameof(entity));
+
+            if (string.IsNullOrWhiteSpace(entity.Name))
+                throw new ArgumentException("Name is required.");
+
+            if (string.IsNullOrWhiteSpace(entity.Domicile))
+                throw new ArgumentException("Domicile is required.");
+
+            if (existingEntities.Any(e =>
+                e.Name.Equals(entity.Name, StringComparison.OrdinalIgnoreCase) &&
+                e.Domicile.Equals(entity.Domicile, StringComparison.OrdinalIgnoreCase)))
+            {
+                throw new InvalidOperationException("An entity with the same Name and Domicile already exists.");
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
This PR implements two requirements for the Gallagher technical interview.

The first one is to display the counter on the Home page. The count should persist when switching between tabs. To achieve this, I created a service that is used by both components. I'm also using the `async` pipe, so that we don't have to manually subscribe to the Observable in the component.

The second requirement is to add a capability to create a sanctioned entity. The name and the domicile fields are required, and we can't have two sanctioned entities with the same name and domicile. Also, the status field is using the Bootstrap switch version 5.1.3. To implement this, I added a new button on the list page that redirects the user to a new page that displays the create form. The validation is done in the front-end without the user having to click on Save. The Save button is disabled if the form is invalid. When the user submits the request, the Save button displays a spinner and is disabled to prevent the user from submitting the form multiple times. If the request succeeds, the user is redirected back to the list, and the new entity should be displayed there. If the request fails, the error message is displayed. A few unit tests were created to test the add component.

Some next steps and improvements were added to the README file.